### PR TITLE
Remove language detection feature

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,6 @@
 import { Telegraf } from "telegraf";
 import i18n from "i18n";
 import { init } from "@sentry/node";
-import LanguageDetect from "languagedetect";
 import { MongoClient } from "mongodb";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -9,8 +8,6 @@ import dotenv from "dotenv";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-const lngDetector = new LanguageDetect();
 
 // Setup =======================================================================
 
@@ -66,16 +63,6 @@ setInterval(async () => {
     .then((users) => users.map((user) => user.username));
 }, 1000 * 60 * 60);
 
-// const changeStream = mongo.db("family").collection("users").watch();
-// changeStream.on("change", async (change) => {
-//   family = await mongo
-//     .db("family")
-//     .collection("users")
-//     .find({})
-//     .toArray()
-//     .then((users) => users.map((user) => user.username));
-// });
-
 function isMe({ message }) {
   return (
     message.from.first_name === "Telegram" ||
@@ -87,7 +74,6 @@ function isChannelBot({ message }) {
 }
 function hasLink(ctx) {
   return ctx.message.entities?.some((entity) => entity.type === "url" || entity.type === "text_link");
-  // return ctx.message.text?.includes("t.me");
 }
 
 const spamChecks = [isChannelBot, hasLink];
@@ -149,16 +135,6 @@ bot.on("message", (ctx) => {
       .then((res) =>
         ctx.deleteMessage(ctx.message.message_id).catch((e) => console.log("CANT DELETE:", ctx.message, e))
       );
-  }
-
-  // Delete messages in english
-  try {
-    const lang = lngDetector.detect(ctx.message.text, 1)[0][0];
-    if (lang === "english") {
-      return ctx.deleteMessage(ctx.message.message_id).catch((e) => console.log("CANT DELETE:", ctx.message, e));
-    }
-  } catch (e) {
-    console.log("CANT DETECT LANGUAGE:", ctx.message, e);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dotenv": "^8.2.0",
     "googleapis": "^52.1.0",
     "i18n": "^0.10.0",
-    "languagedetect": "^2.0.0",
     "lodash": "^4.17.21",
     "mongodb": "^5.6.0",
     "telegraf": "^4.5.2"


### PR DESCRIPTION
Related to #1

Removes the language detection feature that deletes messages written in English from the bot.

- **Code Cleanup**: Removes the import and instantiation of `LanguageDetect` from `index.mjs`, effectively disabling the language detection functionality.
- **Dependency Update**: Eliminates the `languagedetect` package from `package.json`, streamlining the bot's dependencies.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/seniorsoftwarevlogger/bibotybot/issues/1?shareId=cd3784cc-6d97-45db-9458-105ef109b4af).