### PR TITLE
Implement ban replication across all channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,18 @@ SENTRY_DSN=
 ## Features
 
 1. **i18n**: русский, english
+2. **Ban Replication**: The bot now supports replicating ban events across all managed channels upon receiving a ban command from an admin.
+
+### Ban Replication Feature
+
+This new feature allows admins to issue a ban command that will be replicated across all channels managed by the bot. To use this feature, an admin must issue the ban command followed by the user ID of the individual to be banned. The bot will then proceed to ban the specified user from all managed channels.
+
+#### How to Issue a Ban Command
+
+Admins can issue a ban command in the following format:
+
+```
+/ban <user_id>
+```
+
+Where `<user_id>` is the unique identifier of the user to be banned. The bot will confirm once the user has been banned from all managed channels.

--- a/index.mjs
+++ b/index.mjs
@@ -78,6 +78,28 @@ function hasLink(ctx) {
 
 const spamChecks = [isChannelBot, hasLink];
 
+// New functionality to handle ban events and replicate them across all channels
+bot.command('ban', async (ctx) => {
+  // Check if the user issuing the ban command is an admin
+  if (!ctx.from || !myChannels.includes(ctx.from.username)) {
+    return ctx.reply('You are not authorized to perform this action.');
+  }
+
+  const userId = ctx.message.text.split(' ')[1]; // Assuming the command format is "/ban userId"
+  if (!userId) {
+    return ctx.reply('Please specify the user ID to ban.');
+  }
+
+  // Replicate the ban across all channels managed by the bot
+  for (const channel of myChannels) {
+    await ctx.telegram.banChatMember(channel, userId).catch((error) => {
+      console.error(`Failed to ban user ${userId} in channel ${channel}:`, error);
+    });
+  }
+
+  ctx.reply(`User ${userId} has been banned from all managed channels.`);
+});
+
 bot.on("message", (ctx) => {
   if (isMe(ctx) || family.includes(ctx.message.from.username)) return;
 


### PR DESCRIPTION
Related to #3

Implements ban replication across all managed channels and updates documentation to reflect this new feature.

- Adds a new command handler in `index.mjs` for the `/ban` command, which checks if the user issuing the command is an admin and then proceeds to ban the specified user ID across all channels managed by the bot.
- Updates the `README.md` to include a new section on the ban replication feature, explaining how admins can issue ban commands and the expected format for these commands.
- Enhances the "Features" section of the `README.md` to list the new ban replication functionality as a key feature of the bot.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/seniorsoftwarevlogger/bibotybot/issues/3?shareId=777d1e0f-ec56-47e9-9926-3d01b813332d).