### PR TITLE
Block people who tries to post restricted content types

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -104,6 +104,7 @@ bot.on("chat_member", async (ctx) => {
 
 bot.on("chat_boost", (ctx) => {
   console.log("chat_boost", JSON.stringify(ctx.update));
+  restoreUserRights(ctx.message.from.id);
 });
 
 bot.on("removed_chat_boost", (ctx) => {
@@ -154,18 +155,7 @@ bot.on("message", async (ctx) => {
             setTimeout(() => ctx.deleteMessage(botReply.message_id), 10000);
           });
 
-        // ctx.restrictChatMember(ctx.message.from.id, {
-        //   permissions: {
-        //     can_send_messages: true,
-        //     can_send_media_messages: false,
-        //     can_send_polls: false,
-        //     can_send_other_messages: false,
-        //     can_add_web_page_previews: false,
-        //     can_change_info: false,
-        //     can_invite_users: false,
-        //     can_pin_messages: false,
-        //   },
-        // });
+        blockUser(ctx.message.from.id);
       })
       .catch((e) => console.log("CANT DELETE:", ctx.message, e))
       .finally(() => console.log("DELETED", ctx.message.message_id));
@@ -196,7 +186,8 @@ bot.on("message", async (ctx) => {
           .deleteMessage(ctx.message.message_id)
           .catch((e) => console.log("CANT DELETE:", ctx.message, e))
           .finally(() => console.log("DELETED", ctx.message.message_id))
-      );
+      )
+      .then(() => blockUser(ctx.message.from.id));
   }
   // Delete channels
   if (isChannelBot(ctx)) {
@@ -241,3 +232,27 @@ bot.launch(
 // Enable graceful stop
 process.once("SIGINT", () => bot.stop("SIGINT"));
 process.once("SIGTERM", () => bot.stop("SIGTERM"));
+
+function blockUser(userId) {
+  bot.telegram.restrictChatMember(userId, {
+    permissions: {
+      can_send_messages: true,
+      can_send_media_messages: false,
+      can_send_polls: false,
+      can_send_other_messages: false,
+      can_add_web_page_previews: false,
+    },
+  });
+}
+
+function restoreUserRights(userId) {
+  bot.telegram.restrictChatMember(userId, {
+    permissions: {
+      can_send_messages: true,
+      can_send_media_messages: true,
+      can_send_polls: true,
+      can_send_other_messages: true,
+      can_add_web_page_previews: true,
+    },
+  });
+}


### PR DESCRIPTION
Fixes #6

Add functionality to block users who send restricted content types and restore their rights if they boost the channel.

* **Block Users**: Add `blockUser` function to restrict users from sending media and links. Modify `bot.on("message")` event handler to call `blockUser` when a user sends restricted content.
* **Restore User Rights**: Add `restoreUserRights` function to restore user rights if they boost the channel. Modify `bot.on("chat_boost")` event handler to call `restoreUserRights` when a user boosts the channel.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/seniorsoftwarevlogger/bibotybot/issues/6?shareId=f19cd45c-43a3-413c-a68c-7d47a761459c).